### PR TITLE
Fixes an issue that could set a todo in editing mode.

### DIFF
--- a/ui/todo-view.reel/todo-view.js
+++ b/ui/todo-view.reel/todo-view.js
@@ -19,12 +19,18 @@ exports.TodoView = Component.specialize({
     },
 
     enterDocument: {
-        value: function (firstTime) {
-            if (firstTime) {
-                this.element.addEventListener('dblclick', this, false);
-                this.element.addEventListener('blur', this, true);
-                this.element.addEventListener('submit', this, false);
-            }
+        value: function () {
+            this.element.addEventListener('dblclick', this, false);
+            this.element.addEventListener('blur', this, true);
+            this.element.addEventListener('submit', this, false);
+        }
+    },
+
+    exitDocument: {
+        value: function () {
+            this.element.removeEventListener('dblclick', this, false);
+            this.element.removeEventListener('blur', this, true);
+            this.element.removeEventListener('submit', this, false);
         }
     },
 


### PR DESCRIPTION
Avoid to listen to the “dbclick” event after having destroyed a todo in order to avoid to set it in editing mode.